### PR TITLE
Switch from proxy to Spring AOP

### DIFF
--- a/src/example/AppConfig.java
+++ b/src/example/AppConfig.java
@@ -1,0 +1,11 @@
+package example;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Configuration
+@EnableAspectJAutoProxy
+@ComponentScan(basePackages = "example")
+public class AppConfig {
+}

--- a/src/example/Main.java
+++ b/src/example/Main.java
@@ -1,0 +1,13 @@
+package example;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class Main {
+    public static void main(String[] args) {
+        AnnotationConfigApplicationContext context =
+                new AnnotationConfigApplicationContext(AppConfig.class);
+        MyService service = context.getBean(MyService.class);
+        System.out.println(service.process("hello world"));
+        context.close();
+    }
+}

--- a/src/example/MyService.java
+++ b/src/example/MyService.java
@@ -1,0 +1,12 @@
+package example;
+
+public interface MyService {
+    int add(int a, int b);
+
+    @UpperCase(prefix = "")
+    String process(String input);
+
+    default boolean isTransformEnabled() {
+        return false;
+    }
+}

--- a/src/example/MyServiceImpl.java
+++ b/src/example/MyServiceImpl.java
@@ -1,0 +1,20 @@
+package example;
+
+import org.springframework.stereotype.Service;
+@Service
+public class MyServiceImpl implements MyService {
+    @Override
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+    @Override
+    public String process(String input) {
+        return input;
+    }
+
+    @Override
+    public boolean isTransformEnabled() {
+        return true;
+    }
+}

--- a/src/example/TransformAspect.java
+++ b/src/example/TransformAspect.java
@@ -1,0 +1,23 @@
+package example;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class TransformAspect {
+    @Around("@annotation(upperCase)")
+    public Object transform(ProceedingJoinPoint pjp, UpperCase upperCase) throws Throwable {
+        Object target = pjp.getTarget();
+        if (target instanceof MyService service) {
+            Object[] args = pjp.getArgs();
+            if (service.isTransformEnabled() && args != null && args.length > 0 && args[0] instanceof String) {
+                args[0] = ((String) args[0]).toUpperCase();
+            }
+            return pjp.proceed(args);
+        }
+        return pjp.proceed();
+    }
+}

--- a/src/example/UpperCase.java
+++ b/src/example/UpperCase.java
@@ -1,0 +1,12 @@
+package example;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface UpperCase {
+    String prefix() default "";
+}


### PR DESCRIPTION
## Summary
- replace custom proxy with Spring AOP aspect
- configure component scanning and aspect via `AppConfig`
- annotate `MyServiceImpl` as a Spring service
- update `Main` to run within Spring context
- remove old proxy code

## Testing
- `javac src/example/*.java` *(fails: package org.springframework... not found)*
- `java -cp src example.Main` *(fails: class not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685bc92bff88832d884886d128ccdeea