### PR TITLE
Add prefix support to TransformAspect

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,13 @@
-Readme
+This is a simple example demonstrating a Spring AOP aspect.
+
+The `@UpperCase` annotation transforms the first `String` argument of a method
+to upper case. It also supports specifying a `prefix`. The example `MyService`
+interface sets `prefix` to `"Prefix: "` on its `process` method. When
+`TransformAspect` intercepts the call, it will prepend this prefix before the
+upper‑cased value.
+
+Running `Main` will therefore output something like:
+
+```
+Prefix: HELLO WORLD
+```

--- a/src/example/MyService.java
+++ b/src/example/MyService.java
@@ -3,7 +3,7 @@ package example;
 public interface MyService {
     int add(int a, int b);
 
-    @UpperCase(prefix = "")
+    @UpperCase(prefix = "Prefix: ")
     String process(String input);
 
     default boolean isTransformEnabled() {

--- a/src/example/TransformAspect.java
+++ b/src/example/TransformAspect.java
@@ -14,7 +14,8 @@ public class TransformAspect {
         if (target instanceof MyService service) {
             Object[] args = pjp.getArgs();
             if (service.isTransformEnabled() && args != null && args.length > 0 && args[0] instanceof String) {
-                args[0] = ((String) args[0]).toUpperCase();
+                String prefix = upperCase.prefix();
+                args[0] = prefix + ((String) args[0]).toUpperCase();
             }
             return pjp.proceed(args);
         }

--- a/src/example/TransformAspectTest.java
+++ b/src/example/TransformAspectTest.java
@@ -1,0 +1,16 @@
+package example;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class TransformAspectTest {
+    @Test
+    public void processAddsPrefixAndUppercases() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(AppConfig.class);
+        MyService service = context.getBean(MyService.class);
+        String result = service.process("abc");
+        assertEquals("Prefix: ABC", result);
+        context.close();
+    }
+}


### PR DESCRIPTION
## Summary
- enhance TransformAspect to prepend annotation prefix when transforming strings
- demonstrate prefix usage in MyService
- document new prefix behaviour in README
- add TransformAspectTest unit test

## Testing
- `javac $(find src -name "*.java")` *(fails: package org.springframework... not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c252f2ab0832da0fc3cba4ab5d7d8